### PR TITLE
readded with extended false

### DIFF
--- a/server.js
+++ b/server.js
@@ -91,7 +91,7 @@ function respondViaWebsocket(res,ws_response) {
 
 app.use(express.static(__dirname + '/node_modules'));
 app.use(bodyParser.json()); // support json encoded bodies
-//app.use(bodyParser.urlencoded({extended: true})); // support encoded bodies
+app.use(bodyParser.urlencoded({extended: false})); // support encoded bodies
 server.listen(server_port)
 
 


### PR DESCRIPTION
app.use(bodyParser.urlencoded({extended: false})); // support encoded bodies